### PR TITLE
Fix Go version check for major versions

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -19,7 +19,7 @@ new settings exist
 TAG = '0.7.3'
 GOPLS_BASE_URL = 'golang.org/x/tools/gopls@v{tag}'
 
-RE_VER = re.compile(r'go(\d+)\.(\d+)\.(\d+)')
+RE_VER = re.compile(r'go(\d+)\.(\d+)(?:\.(\d+))?')
 
 
 class Gopls(AbstractPlugin):


### PR DESCRIPTION
Major versions, betas, and release candidates do not include a patch version (i.e. go1.18 or go1.18rc1 rather than go1.18.0).

The RE_VER regexp now parses versions without the patch segment. This allows install_or_update to correctly call 'go install' instead of 'go get' for newer Go versions.

----

Without this patch the plugin fails on `go1.18rc1` with the following error:

```
Unable to start subprocess for gopls
Traceback (most recent call last):
  File "/home/cbednarski/.config/sublime-text/Installed Packages/LSP.sublime-package/plugin/core/windows.py", line 245, in start_async
    plugin_class.install_or_update()
  File "/home/cbednarski/.config/sublime-text/Installed Packages/LSP-gopls.sublime-package/plugin.py", line 109, in install_or_update
    'go installation error', stderr, 'returncode', return_code)
ValueError: ('go installation error', "go: go.mod file not found in current directory or any parent directory.\n\t'go get' is no longer supported outside a module.\n\tTo build and install a command, use 'go install' with a version,\n\tlike 'go install example.com/cmd@latest'\n\tFor more information, see https://golang.org/doc/go-get-install-deprecation\n\tor run 'go help get' or 'go help install'.\n", 'returncode', 1)
```