### PR TITLE
Remove deprecated gopls.experimentalTemplateSupport setting

### DIFF
--- a/LSP-gopls.sublime-settings
+++ b/LSP-gopls.sublime-settings
@@ -81,9 +81,6 @@
     // (Experimental) experimentalPostfixCompletions enables artifical method snippets
     // such as "someSlice.sort!".
     "gopls.experimentalPostfixCompletions": true,
-    // (Experimental) experimentalTemplateSupport opts into the experimental support
-    // for template files.
-    "gopls.experimentalTemplateSupport": false,
     // templateExtensions gives the extensions of file names that are treateed
     // as template files. (The extension
     // is the part of the file name after the final dot.)

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -70,11 +70,6 @@
                       "markdownDescription": "(Experimental) experimentalPackageCacheKey controls whether to use a coarser cache key\nfor package type information to increase cache hits. This setting removes\nthe user's environment, build flags, and working directory from the cache\nkey, which should be a safe change as all relevant inputs into the type\nchecking pass are already hashed into the key. This is temporarily guarded\nby an experiment because caching behavior is subtle and difficult to\ncomprehensively test.\n",
                       "type": "boolean"
                     },
-                    "gopls.experimentalTemplateSupport": {
-                      "default": false,
-                      "markdownDescription": "(Experimental) experimentalTemplateSupport opts into the experimental support\nfor template files.\n",
-                      "type": "boolean"
-                    },
                     "gopls.experimentalWorkspaceModule": {
                       "default": false,
                       "markdownDescription": "(Experimental) experimentalWorkspaceModule opts a user into the experimental support\nfor multi-module workspaces.\n",


### PR DESCRIPTION
Starting the server shows `gopls.experimentalTemplateSupport is deprecated` in the status bar.