### PR TITLE
Implement printing test results to the Terminus panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_STORE
+test_data/

--- a/LSP-gopls.sublime-settings
+++ b/LSP-gopls.sublime-settings
@@ -5,6 +5,8 @@
   ],
   "selector": "source.go | source.gomod",
   "settings": {
+    "gopls.terminusAutoClose": false,
+    "gopls.terminusUsePanel": true,
     // (Experimental) experimentalUseInvalidMetadata enables gopls to fall back on outdated
     // package metadata to provide editor features if the go command fails to
     // load packages for some reason (like an invalid go.mod file). This will
@@ -136,6 +138,4 @@
     // (For Debugging) verboseOutput enables additional debug logging.
     "gopls.verboseOutput": false,
   },
-  "gopls.terminusAutoClose": false,
-  "gopls.terminusUsePanel": false
 }

--- a/LSP-gopls.sublime-settings
+++ b/LSP-gopls.sublime-settings
@@ -5,8 +5,8 @@
   ],
   "selector": "source.go | source.gomod",
   "settings": {
-    "gopls.terminusAutoClose": false,
-    "gopls.terminusUsePanel": true,
+    "gopls.testsTerminusAutoClose": false,
+    "gopls.testsTerminusUsePanel": true,
     // (Experimental) experimentalUseInvalidMetadata enables gopls to fall back on outdated
     // package metadata to provide editor features if the go command fails to
     // load packages for some reason (like an invalid go.mod file). This will

--- a/LSP-gopls.sublime-settings
+++ b/LSP-gopls.sublime-settings
@@ -5,8 +5,8 @@
   ],
   "selector": "source.go | source.gomod",
   "settings": {
-    "gopls.testsTerminusAutoClose": false,
-    "gopls.testsTerminusUsePanel": true,
+    "gopls.testsTerminusPanelAutoClose": false,
+    "gopls.testsUseTerminusPanel": true,
     // (Experimental) experimentalUseInvalidMetadata enables gopls to fall back on outdated
     // package metadata to provide editor features if the go command fails to
     // load packages for some reason (like an invalid go.mod file). This will

--- a/LSP-gopls.sublime-settings
+++ b/LSP-gopls.sublime-settings
@@ -135,5 +135,7 @@
     "gopls.usePlaceholders": false,
     // (For Debugging) verboseOutput enables additional debug logging.
     "gopls.verboseOutput": false,
-  }
+  },
+  "gopls.terminusAutoClose": false,
+  "gopls.terminusUsePanel": false
 }

--- a/LSP-gopls.sublime-settings
+++ b/LSP-gopls.sublime-settings
@@ -5,8 +5,8 @@
   ],
   "selector": "source.go | source.gomod",
   "settings": {
-    "gopls.testsTerminusPanelAutoClose": false,
-    "gopls.testsUseTerminusPanel": true,
+    "closeTestResultsWhenFinished": false,
+    "runTestsInPanel": true,
     // (Experimental) experimentalUseInvalidMetadata enables gopls to fall back on outdated
     // package metadata to provide editor features if the go command fails to
     // load packages for some reason (like an invalid go.mod file). This will

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Uses [Go Language Server][gopls-repo] to provide validation, formatting and othe
 
 * Go (Golang) must be installed and configured in your `PATH`
 
+#### Optionals
+
+LSP-gopls implements the ability for results from Go Tests to be output into a panel. In order to support this, please install [Terminus][terminus]
+
 ### Installation
 
 * Install [LSP][lsp-repo] and [LSP-gopls][lsp-gopls] from Package Control. Optionally install [Sublime Gomod][sublime-gomod] for gomod support.
@@ -30,3 +34,4 @@ Configure the default Go language server ('gopls'). In most cases, configuring t
 [gopls-analyzers]: https://github.com/golang/tools/blob/master/gopls/doc/analyzers.md
 [sublime-gomod]: https://packagecontrol.io/packages/Gomod
 [golang-installation]: https://golang.org/doc/install
+[terminus]: https://packagecontrol.io/packages/Terminus

--- a/plugin.py
+++ b/plugin.py
@@ -48,9 +48,9 @@ def open_tests_in_terminus(session: Session, window: Optional[sublime.Window], a
             'title': 'Go Test',
             'cmd': command_to_run,
             'cwd': go_test_directory,
-            'auto_close': get_setting(session, 'gopls.terminusAutoClose', False)
+            'auto_close': get_setting(session, 'closeTestResultsWhenFinished', False)
         }
-        if get_setting(session, 'gopls.terminusUsePanel', True):
+        if get_setting(session, 'runTestsInPanel', True):
             terminus_args['panel_name'] = 'Go Test'
         window.run_command('terminus_open', terminus_args)
 

--- a/plugin.py
+++ b/plugin.py
@@ -3,7 +3,7 @@
 import sublime
 
 from LSP.plugin import AbstractPlugin, register_plugin, unregister_plugin
-from LSP.plugin.core.typing import Any, Optional, Tuple, Mapping, Callable, List, TypedDict, Union
+from LSP.plugin.core.typing import Any, Optional, Tuple, Mapping, Callable, List, Union
 
 from shutil import which
 import subprocess
@@ -42,29 +42,26 @@ def open_tests_in_terminus(window: Optional[sublime.Window], arguments: List) ->
 
     if not Terminus:
         sublime.error_message(
-            'Cannot run executable. You need to install the "Terminus" package and then restart Sublime Text')
+            'Cannot run executable. You need to install the \'Terminus\' package and then restart Sublime Text')
         return
 
-    test_file = os.path.dirname(arguments[0]).lstrip("file:").replace("%20", " ")
-    args = [test_file]
+    go_test_directory = os.path.dirname(arguments[0]).lstrip('file:').replace('%20', ' ')
+    args = [go_test_directory]
     for test_command in arguments[1]:
         runnable_args = args
-        runnable_args.extend(["-v", "-count=1", "-run", "^{0}$".format(test_command)])
-        print(runnable_args)
-        base_command = ["go", "test"]
-        base_command.extend(runnable_args)
+        runnable_args.extend(['-v', '-count=1', '-run', '^{0}$'.format(test_command)])
+        command_to_run = ['go', 'test']
+        command_to_run.extend(runnable_args)
 
-        command_to_run = base_command
-        print(command_to_run)
         terminus_args = {
-            "title": "Go Test",
-            "cmd": command_to_run,
-            "cwd": test_file,
-            "auto_close": get_setting(view, "gopls.terminusAutoClose", False)
+            'title': 'Go Test',
+            'cmd': command_to_run,
+            'cwd': go_test_directory,
+            'auto_close': get_setting(view, 'gopls.terminusAutoClose', False)
         }
-        if get_setting(view, "gopls.terminusUsePanel", False):
-            terminus_args["panel_name"] = "Go Test"
-        window.run_command("terminus_open", terminus_args)
+        if get_setting(view, 'gopls.terminusUsePanel', True):
+            terminus_args['panel_name'] = 'Go Test'
+        window.run_command('terminus_open', terminus_args)
 
 
 class Gopls(AbstractPlugin):
@@ -161,19 +158,19 @@ class Gopls(AbstractPlugin):
             fp.write(cls.server_version())
 
     def on_pre_server_command(self, command: Mapping[str, Any], done_callback: Callable[[], None]) -> bool:
-        command_name = command["command"]
+        command_name = command['command']
         try:
             session = self.weaksession()
             if not session:
                 return False
-            if command_name in ("gopls.test"):
-                open_tests_in_terminus(sublime.active_window(), command["arguments"])
+            if command_name in ('gopls.test'):
+                open_tests_in_terminus(sublime.active_window(), command['arguments'])
                 done_callback()
                 return True
             else:
                 return False
         except Exception as ex:
-            print("Exception handling command {}: {}".format(command_name, ex))
+            print('Exception handling command {}: {}'.format(command_name, ex))
             return False
 
 
@@ -218,12 +215,12 @@ def to_int(value: Optional[str]) -> int:
 def _is_binary_available(path) -> bool:
     return bool(which(path))
 
-def get_setting(view: sublime.View = None, key: str = "", default: Optional[Union[str, bool]] = None) -> Any:
+def get_setting(view: sublime.View = None, key: str = '', default: Optional[Union[str, bool, List[str]]] = None) -> Any:
     if view:
         settings = view.settings()
         if settings.has(key):
             return settings.get(key)
-    settings = sublime.load_settings('LSP-gopls.sublime-settings').get("settings", {})
+    settings = sublime.load_settings('LSP-gopls.sublime-settings').get('settings', {})
     return settings.get(key, default)
 
 

--- a/plugin.py
+++ b/plugin.py
@@ -30,9 +30,6 @@ RE_VER = re.compile(r'go(\d+)\.(\d+)(?:\.(\d+))?')
 
 
 def open_tests_in_terminus(session: Session, window: Optional[sublime.Window], arguments: Tuple[str, List[str], None]) -> None:
-    if not session:
-        return
-
     if not window:
         return
 
@@ -82,8 +79,9 @@ class Gopls(AbstractPlugin):
     @classmethod
     def _is_gopls_installed(cls) -> bool:
         binary = 'gopls.exe' if sublime.platform() == 'windows' else 'gopls'
-        command = get_setting(None,'command', [os.path.join(cls.basedir(), 'bin', binary)])
-        gopls_binary = command[0].replace('${storage_path}', cls.storage_path())
+        command = [os.path.join(cls.basedir(), 'bin', binary)]
+
+        gopls_binary = sublime.expand_variables(command[0], {'storage_path': cls.storage_path()})
         if sublime.platform() == 'windows' and not gopls_binary.endswith('.exe'):
             gopls_binary = gopls_binary + '.exe'
         return _is_binary_available(gopls_binary)
@@ -212,14 +210,11 @@ def _is_binary_available(path) -> bool:
 
 
 def get_setting(session: Session, key: str, default: Optional[Union[str, bool, List[str]]] = None) -> Any:
-    if not session:
+    value = session.config.settings.get(key)
+    if value is None:
         return default
 
-    setting = session.config.settings.get(key)
-    if not setting:
-        return default
-
-    return setting
+    return value
 
 
 def plugin_loaded():

--- a/plugin.py
+++ b/plugin.py
@@ -48,10 +48,7 @@ def open_tests_in_terminus(window: Optional[sublime.Window], arguments: List) ->
     go_test_directory = os.path.dirname(arguments[0]).lstrip('file:').replace('%20', ' ')
     args = [go_test_directory]
     for test_command in arguments[1]:
-        runnable_args = args
-        runnable_args.extend(['-v', '-count=1', '-run', '^{0}$'.format(test_command)])
-        command_to_run = ['go', 'test']
-        command_to_run.extend(runnable_args)
+        command_to_run = ['go', 'test'] + args + ['-v', '-count=1', '-run', '^{0}$'.format(test_command)]
 
         terminus_args = {
             'title': 'Go Test',

--- a/plugin.py
+++ b/plugin.py
@@ -3,13 +3,20 @@
 import sublime
 
 from LSP.plugin import AbstractPlugin, register_plugin, unregister_plugin
-from LSP.plugin.core.typing import Any, Optional, Tuple
+from LSP.plugin.core.typing import Any, Optional, Tuple, Mapping, Callable, List, TypedDict, Union
 
 from shutil import which
 import subprocess
 import tempfile
 import os
 import re
+
+try:
+    import Terminus  # type: ignore
+except ImportError:
+    Terminus = None
+
+# {'command': 'gopls.test', 'arguments': ['file:///Users/zacharyschulze/Library/Application%20Support/Sublime%20Text/Packages/LSP-gopls/test_data/mmath/math_test.go', ['TestAdd'], None], 'workDoneToken': 'wd6'}
 
 '''
 Current version of gopls that the plugin installs
@@ -20,6 +27,44 @@ TAG = '0.8.4'
 GOPLS_BASE_URL = 'golang.org/x/tools/gopls@v{tag}'
 
 RE_VER = re.compile(r'go(\d+)\.(\d+)(?:\.(\d+))?')
+
+
+def open_tests_in_terminus(window: Optional[sublime.Window], arguments: List) -> None:
+    if len(arguments) != 3:
+        return
+
+    if not window:
+        return
+
+    view = window.active_view()
+    if not view:
+        return
+
+    if not Terminus:
+        sublime.error_message(
+            'Cannot run executable. You need to install the "Terminus" package and then restart Sublime Text')
+        return
+
+    test_file = os.path.dirname(arguments[0]).lstrip("file:").replace("%20", " ")
+    args = [test_file]
+    for test_command in arguments[1]:
+        runnable_args = args
+        runnable_args.extend(["-v", "-count=1", "-run", "^{0}$".format(test_command)])
+        print(runnable_args)
+        base_command = ["go", "test"]
+        base_command.extend(runnable_args)
+
+        command_to_run = base_command
+        print(command_to_run)
+        terminus_args = {
+            "title": "Go Test",
+            "cmd": command_to_run,
+            "cwd": test_file,
+            "auto_close": get_setting(view, "gopls.terminusAutoClose", False)
+        }
+        if get_setting(view, "gopls.terminusUsePanel", False):
+            terminus_args["panel_name"] = "Go Test"
+        window.run_command("terminus_open", terminus_args)
 
 
 class Gopls(AbstractPlugin):
@@ -46,7 +91,7 @@ class Gopls(AbstractPlugin):
     @classmethod
     def _is_gopls_installed(cls) -> bool:
         binary = 'gopls.exe' if sublime.platform() == 'windows' else 'gopls'
-        command = get_setting(
+        command = get_setting(None,
             'command', [os.path.join(cls.basedir(), 'bin', binary)]
         )
         gopls_binary = command[0].replace('${storage_path}', cls.storage_path())
@@ -115,6 +160,22 @@ class Gopls(AbstractPlugin):
         with open(os.path.join(cls.basedir(), 'VERSION'), 'w') as fp:
             fp.write(cls.server_version())
 
+    def on_pre_server_command(self, command: Mapping[str, Any], done_callback: Callable[[], None]) -> bool:
+        command_name = command["command"]
+        try:
+            session = self.weaksession()
+            if not session:
+                return False
+            if command_name in ("gopls.test"):
+                open_tests_in_terminus(sublime.active_window(), command["arguments"])
+                done_callback()
+                return True
+            else:
+                return False
+        except Exception as ex:
+            print("Exception handling command {}: {}".format(command_name, ex))
+            return False
+
 
 def run_go_command(
     env_vars: dict,
@@ -157,9 +218,12 @@ def to_int(value: Optional[str]) -> int:
 def _is_binary_available(path) -> bool:
     return bool(which(path))
 
-
-def get_setting(key: str, default=None) -> Any:
-    settings = sublime.load_settings('LSP-gopls.sublime-settings')
+def get_setting(view: sublime.View = None, key: str = "", default: Optional[Union[str, bool]] = None) -> Any:
+    if view:
+        settings = view.settings()
+        if settings.has(key):
+            return settings.get(key)
+    settings = sublime.load_settings('LSP-gopls.sublime-settings').get("settings", {})
     return settings.get(key, default)
 
 

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -25,12 +25,12 @@
                   "additionalProperties": false,
                   "type": "object",
                   "properties": {
-                    "gopls.testsTerminusPanelAutoClose": {
+                    "closeTestResultsWhenFinished": {
                       "default": false,
                       "markdownDescription": "Controls if the terminus panel/tab will auto close on completion.",
                       "type": "boolean"
                     },
-                    "gopls.testsUseTerminusPanel": {
+                    "runTestsInPanel": {
                       "default": true,
                       "markdownDescription": "Controls if the terminus outputs to a Sublime Panel instead of a Sublime Tab.",
                       "type": "boolean"

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -27,12 +27,12 @@
                   "properties": {
                     "closeTestResultsWhenFinished": {
                       "default": false,
-                      "markdownDescription": "Controls if the terminus panel/tab will auto close on completion.",
+                      "markdownDescription": "Controls if the Terminus panel/tab will auto close on tests completing.",
                       "type": "boolean"
                     },
                     "runTestsInPanel": {
                       "default": true,
-                      "markdownDescription": "Controls if the terminus outputs to a Sublime Panel instead of a Sublime Tab.",
+                      "markdownDescription": "Controls if the test results output to a panel instead of a tab.",
                       "type": "boolean"
                     },
                     "gopls.experimentalUseInvalidMetadata": {

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -25,12 +25,12 @@
                   "additionalProperties": false,
                   "type": "object",
                   "properties": {
-                    "gopls.testsTerminusAutoClose": {
+                    "gopls.testsTerminusPanelAutoClose": {
                       "default": false,
                       "markdownDescription": "Controls if the terminus panel/tab will auto close on completion.",
                       "type": "boolean"
                     },
-                    "gopls.testsTerminusUsePanel": {
+                    "gopls.testsUseTerminusPanel": {
                       "default": true,
                       "markdownDescription": "Controls if the terminus outputs to a Sublime Panel instead of a Sublime Tab.",
                       "type": "boolean"

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -25,6 +25,16 @@
                   "additionalProperties": false,
                   "type": "object",
                   "properties": {
+                    "gopls.terminusAutoClose": {
+                      "default": false,
+                      "markdownDescription": "terminusAutoClose controls if the terminus panel/tab will auto close on completion\n",
+                      "type": "boolean"
+                    },
+                    "gopls.terminusUsePanel": {
+                      "default": false,
+                      "markdownDescription": "terminusUsePanel controls if the terminus outputs to a Sublime Panel instead of a Sublime Tab\n",
+                      "type": "boolean"
+                    },
                     "gopls.experimentalUseInvalidMetadata": {
                       "default": false,
                       "markdownDescription": "(Experimental) experimentalUseInvalidMetadata enables gopls to fall back on outdated\npackage metadata to provide editor features if the go command fails to\nload packages for some reason (like an invalid go.mod file). This will\neventually be the default behavior, and this setting will be removed.\n",
@@ -32,12 +42,12 @@
                     },
                     "gopls.allowImplicitNetworkAccess": {
                       "default": false,
-                      "markdownDescription": "(Experimental) allowImplicitNetworkAccess disables GOPROXY=off, allowing implicit module\ndownloads rather than requiring user action. This option will eventually\nbe removed.\n",
+                      "markdownDescription": "(Experimental) allowImplicitNetworkAccess disables `GOPROXY=off`, allowing implicit module\ndownloads rather than requiring user action. This option will eventually\nbe removed.\n",
                       "type": "boolean"
                     },
                     "gopls.allowModfileModifications": {
                       "default": false,
-                      "markdownDescription": "(Experimental) allowModfileModifications disables -mod=readonly, allowing imports from\nout-of-scope modules. This option will eventually be removed.\n",
+                      "markdownDescription": "(Experimental) allowModfileModifications disables `-mod=readonly`, allowing imports from\nout-of-scope modules. This option will eventually be removed.\n",
                       "type": "boolean"
                     },
                     "gopls.buildFlags": {

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -25,14 +25,14 @@
                   "additionalProperties": false,
                   "type": "object",
                   "properties": {
-                    "gopls.terminusAutoClose": {
+                    "gopls.testsTerminusAutoClose": {
                       "default": false,
-                      "markdownDescription": "terminusAutoClose controls if the terminus panel/tab will auto close on completion\n",
+                      "markdownDescription": "Controls if the terminus panel/tab will auto close on completion.",
                       "type": "boolean"
                     },
-                    "gopls.terminusUsePanel": {
-                      "default": false,
-                      "markdownDescription": "terminusUsePanel controls if the terminus outputs to a Sublime Panel instead of a Sublime Tab\n",
+                    "gopls.testsTerminusUsePanel": {
+                      "default": true,
+                      "markdownDescription": "Controls if the terminus outputs to a Sublime Panel instead of a Sublime Tab.",
                       "type": "boolean"
                     },
                     "gopls.experimentalUseInvalidMetadata": {


### PR DESCRIPTION
### What

Implements `go test` results to output to a terminus panel

### Known Bugs

- When selecting a single test to run, it still runs all tests within a go file