### PR TITLE
refactor: replace deprecated initializationOptions with initialization_options

### DIFF
--- a/scripts/update-schema-settings.py
+++ b/scripts/update-schema-settings.py
@@ -17,7 +17,7 @@ SCHEMA_TEMPLATE = {
                     "definitions": {
                         "PluginConfig": {
                             "properties": {
-                                "initializationOptions": {
+                                "initialization_options": {
                                     "additionalProperties": False,
                                     "type": "object",
                                     "properties": {},

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -10,7 +10,7 @@
           "definitions": {
             "PluginConfig": {
               "properties": {
-                "initializationOptions": {
+                "initialization_options": {
                   "additionalProperties": false,
                   "type": "object",
                   "properties": {}


### PR DESCRIPTION
In https://github.com/sublimelsp/LSP/releases/tag/4070-2.9.0 `config.init_options`
and `initializationOptions` in settings were deprecated.

(This is a semi-automatically created PR that might not
have been tested manually.)
